### PR TITLE
DM-27049: Fix BpsConfig after changes caused warnings

### DIFF
--- a/python/lsst/ctrl/bps/bps_config.py
+++ b/python/lsst/ctrl/bps/bps_config.py
@@ -132,23 +132,28 @@ class BpsConfig(Config):
     def search(self, key, opt=None):
         """Searches for key using given opt following hierarchy rules.
 
-        Hierarchy rules: current vals, search object, search order
-        of config sections.
+        Search hierarchy rules: current values, a given search object, and
+        search order of config sections.
 
         Parameters
         ----------
         key: `str`
-            Key to look for in config
+            Key to look for in config.
         opt: `dict`, optional
-            Options to use while searching
-                curvals: `dict`, optional
-                    Means to pass in values for search order key (curr_<sectname>) or variable replacements
-                default: optional
-                    Value to return if not found
-                replaceVars: `bool`, default = True
-                    If search result is string, whether to replace variables inside it
-                required: `bool`, default = False
-                    If replacing variables, whether to raise exception if variable is undefined
+            Options dictionary to use while searching.  All are optional.
+
+            ``"curvals"``
+                    Means to pass in values for search order key
+                    (curr_<sectname>) or variable replacements.
+                    (`dict`, optional)
+            ``"default"``
+                    Value to return if not found. (`Any`, optional)
+            ``"replaceVars"``
+                    If search result is string, whether to replace variables
+                    inside it. By default set to True. (`bool`)
+            ``"required"``
+                    If replacing variables, whether to raise exception if
+                    variable is undefined. By default set to False. (`bool`)
 
         Returns
         -------
@@ -221,7 +226,7 @@ class BpsConfig(Config):
 
         if not found and opt.get("required", False):
             print("\n\nError: search for %s failed" % (key))
-            print("\tcurrent = ", Config.get(self, "current"))
+            print("\tcurrent = ", self.get("current"))
             print("\topt = ", opt)
             print("\tcurvals = ", curvals)
             print("\n\n")

--- a/python/lsst/ctrl/bps/bps_core.py
+++ b/python/lsst/ctrl/bps/bps_core.py
@@ -50,6 +50,9 @@ from lsst.ctrl.bps.bps_config import BpsConfig
 from lsst.daf.butler.core.config import Loader
 from lsst.ctrl.bps.bps_draw import draw_networkx_dot
 
+# Config section search order
+BPS_SEARCH_ORDER = ["payload", "pipetask", "site", "global"]
+
 # Graph property
 FILENODE = 0
 TASKNODE = 1
@@ -160,7 +163,7 @@ class BpsCore():
 
     def __init__(self, configFile, **kwargs):
         self.config_log(False)
-        self.config = BpsConfig(configFile)
+        self.config = BpsConfig(configFile, BPS_SEARCH_ORDER)
         _LOG.debug("Core kwargs = '%s'", kwargs)
         self.config[".global.timestamp"] = "{:%Y%m%dT%Hh%Mm%Ss}".format(datetime.datetime.now())
         if "uniqProcName" not in self.config:


### PR DESCRIPTION
After recent code changes in other ticket, bpsub started printing
bunches of warning messages like the following:
WARNING::10/02/2020 18:31:00::Missing search section...

This was due to sub-configs being created with same top-level
search_order.  Modified BpsConfig to take search_order as an
optional argument and fixed creation of object in bps_core.py
to pass the BPS search_order into the constructor.

Also fixed the following while in the bps_config.py code:
* Fixed bug when printing an error message that assumed an
  internal value existed (current).
* Fixed function signatures for __getitem__ and __contains__.
* Added info to search docstring about valid keys for the
  search options.