### PR TITLE
DM-27147: Update ctrl_bps to use new timestamp format.

### DIFF
--- a/doc/lsst.ctrl.bps/pipelines_check.yaml
+++ b/doc/lsst.ctrl.bps/pipelines_check.yaml
@@ -14,7 +14,7 @@ payload:
   payloadName: pcheck
   butlerConfig: ${PIPELINES_CHECK_DIR}/DATA_REPO/butler.yaml
   inCollection: HSC/calib,HSC/raw/all,refcats
-  outCollection: "shared/pipecheck/{timestamp}"
+  outCollection: "u/${USER}/pipelines_check/{timestamp}"
   dataQuery: exposure=903342 AND detector=10
 
 pipetask:

--- a/doc/lsst.ctrl.bps/quickstart.rst
+++ b/doc/lsst.ctrl.bps/quickstart.rst
@@ -122,11 +122,9 @@ The remaining information tells BPS which workflow management system is being
 used, how to convert Datasets and Pipetasks into compute jobs and what
 resources those compute jobs need.
 
-
 .. literalinclude:: pipelines_check.yaml
    :language: YAML
    :caption: ${CTRL_BPS_DIR}/doc/lsst.ctrl.bps/pipelines_check.yaml
-
 
 .. _bps-submit:
 

--- a/python/lsst/ctrl/bps/submit.py
+++ b/python/lsst/ctrl/bps/submit.py
@@ -23,13 +23,13 @@
 """
 
 import getpass
-import datetime
 import logging
 import os
 import pickle
 import time
 
 from lsst.utils import doImport
+from lsst.obs.base import Instrument
 
 from .bps_draw import draw_networkx_dot
 from .pre_transform import pre_transform, cluster_quanta
@@ -90,7 +90,7 @@ def create_submission(config):
     """
     subtime = time.time()
 
-    config[".bps_defined.timestamp"] = "{:%Y%m%dT%Hh%Mm%Ss}".format(datetime.datetime.now())
+    config[".bps_defined.timestamp"] = Instrument.makeCollectionTimestamp()
     if "uniqProcName" not in config:
         config[".bps_defined.uniqProcName"] = config["outCollection"].replace("/", "_")
     if "operator" not in config:

--- a/ups/ctrl_bps.table
+++ b/ups/ctrl_bps.table
@@ -2,6 +2,7 @@ setupRequired(sconsUtils)
 setupRequired(utils)
 setupRequired(daf_butler)
 setupRequired(pipe_base)
+setupRequired(obs_base)
 setupOptional(ctrl_mpexec)
 
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)


### PR DESCRIPTION
Update code to use new Instrument.makeCollectionTimestamp()
when creating the timestamp for use in naming output collections.

Also update collection names in the sample yaml provided in
the docs.  Note:  This commit only changed the output collection,
because at this time pipelines_check has not been changed.  When
pipelines_check has been changed to use the "HSC/defaults"
collection, the example's input collection should also be changed.