### PR TITLE
DM-28929: Allow non-string HTCondor attributes 

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -3,9 +3,10 @@
 This configuration only affects single-package Sphinx documentation builds.
 """
 
-from documenteer.sphinxconfig.stackconf import build_package_configs
-import lsst.ctrl.bps
+from documenteer.conf.pipelinespkg import *  # noqa: F403, import *
 
-
-_g = globals()
-_g.update(build_package_configs(project_name="ctrl_bps", version=lsst.ctrl.bps.version.__version__))
+project = "ctrl_bps"
+html_theme_options["logotext"] = project     # noqa: F405, unknown name
+html_title = project
+html_short_title = project
+doxylink = {}

--- a/doc/lsst.ctrl.bps/index.rst
+++ b/doc/lsst.ctrl.bps/index.rst
@@ -39,3 +39,4 @@ Python API reference
 .. automodapi:: lsst.ctrl.bps
    :no-main-docstr:
    :no-inheritance-diagram:
+   :no-inherited-members:

--- a/doc/lsst.ctrl.bps/pipelines_check.yaml
+++ b/doc/lsst.ctrl.bps/pipelines_check.yaml
@@ -1,4 +1,4 @@
-pipelineYaml: "${OBS_SUBARU_DIR}/pipelines/DRP.yaml:processCcd"
+pipelineYaml: "${OBS_SUBARU_DIR}/pipelines/DRP.yaml#processCcd"
 templateDataId: "{tract}_{patch}_{band}_{visit}_{exposure}_{detector}"
 project: dev
 campaign: quick

--- a/doc/lsst.ctrl.bps/quickstart.rst
+++ b/doc/lsst.ctrl.bps/quickstart.rst
@@ -100,7 +100,7 @@ file (recommended)
 
 .. code-block:: YAML
 
-   pipelineYaml: "${OBS_SUBARU_DIR}/pipelines/DRP.yaml:processCcd"
+   pipelineYaml: "${OBS_SUBARU_DIR}/pipelines/DRP.yaml#processCcd"
 
 or a pre-made file containing a serialized QuantumGraph, for example
 
@@ -367,7 +367,7 @@ Supported settings
 
        pipetask:
          pipetask_init:
-           runQuantumCommand: "${CTRL_MPEXEC_DIR}/bin/pipetask --long-log run -b {butlerConfig} -i {inCollection} --output-run {outCollection} --init-only --skip-existing --register-dataset-types --qgraph {qgraph_file} --no-versions"
+           runQuantumCommand: "${CTRL_MPEXEC_DIR}/bin/pipetask --long-log run -b {butlerConfig} -i {inCollection} --output-run {outCollection} --init-only --skip-existing --register-dataset-types --qgraph {qgraphFile} --no-versions"
            requestMemory: 2048
 
 **templateDataId**

--- a/python/lsst/ctrl/bps/wms/htcondor/lssthtc.py
+++ b/python/lsst/ctrl/bps/wms/htcondor/lssthtc.py
@@ -181,19 +181,24 @@ class RestrictedDict(MutableMapping):
 
 
 def htc_escape(value):
-    """Escape characters in given string based upon HTCondor syntax.
+    """Escape characters in given value based upon HTCondor syntax.
 
     Parameter
     ----------
-    value : `str`
-        String that needs to have characters escaped.
+    value : `Any`
+        Value that needs to have characters escaped if string
 
     Returns
     -------
-    new_value : `str`
-        Given string with characters escaped.
+    new_value : `Any`
+        Given value with characters escaped appropriate for HTCondor if string.
     """
-    return value.replace("\\", "\\\\").replace('"', '\\"').replace("'", "''").replace("&quot;", '"')
+    if isinstance(value, str):
+        newval = value.replace('"', '""').replace("'", "''").replace("&quot;", '"')
+    else:
+        newval = value
+
+    return newval
 
 
 def htc_write_attribs(stream, attrs):
@@ -207,7 +212,12 @@ def htc_write_attribs(stream, attrs):
         HTCondor job attributes (dictionary of attribute key, value)
     """
     for key, value in attrs.items():
-        print(f'+{key} = "{htc_escape(value)}"', file=stream)
+        if isinstance(value, str):
+            pval = f'"{htc_escape(value)}"'
+        else:
+            pval = value
+
+        print(f'+{key} = {pval}', file=stream)
 
 
 def htc_write_condor_file(filename, job_name, job, job_attrs):

--- a/python/lsst/ctrl/bps/wms/htcondor/lssthtc.py
+++ b/python/lsst/ctrl/bps/wms/htcondor/lssthtc.py
@@ -186,7 +186,7 @@ def htc_escape(value):
     Parameter
     ----------
     value : `Any`
-        Value that needs to have characters escaped if string
+        Value that needs to have characters escaped if string.
 
     Returns
     -------
@@ -212,6 +212,7 @@ def htc_write_attribs(stream, attrs):
         HTCondor job attributes (dictionary of attribute key, value)
     """
     for key, value in attrs.items():
+        # Make sure strings are syntactically correct for HTCondor.
         if isinstance(value, str):
             pval = f'"{htc_escape(value)}"'
         else:

--- a/tests/test_lssthtc.py
+++ b/tests/test_lssthtc.py
@@ -1,0 +1,52 @@
+# This file is part of ctrl_bps.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import unittest
+
+try:
+    import htcondor
+    from lsst.ctrl.bps.wms.htcondor import lssthtc
+except ImportError:
+    htcondor = None
+
+
+@unittest.skipIf(not htcondor, "Warning: Missing HTCondor API. Skipping")
+class TestLsstHtc(unittest.TestCase):
+
+    def testHtcEscapeInt(self):
+        self.assertEqual(lssthtc.htc_escape(100), 100)
+
+    def testHtcEscapeDouble(self):
+        self.assertEqual(lssthtc.htc_escape('"double"'), '""double""')
+
+    def testHtcEscapeSingle(self):
+        self.assertEqual(lssthtc.htc_escape("'single'"), "''single''")
+
+    def testHtcEscapeNoSideEffect(self):
+        val = "'val'"
+        self.assertEqual(lssthtc.htc_escape(val), "''val''")
+        self.assertEqual(val, "'val'")
+
+    def testHtcEscapeQuot(self):
+        self.assertEqual(lssthtc.htc_escape("&quot;val&quot;"), '"val"')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lssthtc.py
+++ b/tests/test_lssthtc.py
@@ -27,7 +27,7 @@ except ImportError:
     htcondor = None
 
 
-@unittest.skipIf(not htcondor, "Warning: Missing HTCondor API. Skipping")
+@unittest.skipIf(htcondor is None, "Warning: Missing HTCondor API. Skipping")
 class TestLsstHtc(unittest.TestCase):
 
     def testHtcEscapeInt(self):


### PR DESCRIPTION
The HTCondor plugin's code assumed that attribute value was a string.  But Walltime on NCSA's DAC cluster needs to be an integer.  So this ticket fixed the plugin code.   Also some unrelated doc changes.