### PR TITLE
DM-28960: Change example and doc to get Chained collection.

### DIFF
--- a/doc/lsst.ctrl.bps/pipelines_check.yaml
+++ b/doc/lsst.ctrl.bps/pipelines_check.yaml
@@ -20,7 +20,7 @@ payload:
 
 pipetask:
   pipetaskInit:
-    runQuantumCommand: "${CTRL_MPEXEC_DIR}/bin/pipetask --long-log run -b {butlerConfig} -i {inCollection} --output {output} --output-run {outCollection} --init-only --skip-existing --register-dataset-types --qgraph {qgraphFile} --clobber-partial-outputs --no-versions"
+    runQuantumCommand: "${CTRL_MPEXEC_DIR}/bin/pipetask --long-log run -b {butlerConfig} -i {inCollection} --output {output} --output-run {outCollection} --init-only --register-dataset-types --qgraph {qgraphFile} --clobber-partial-outputs --no-versions"
   assembleCoadd:
     requestMemory: 8192
 

--- a/doc/lsst.ctrl.bps/pipelines_check.yaml
+++ b/doc/lsst.ctrl.bps/pipelines_check.yaml
@@ -14,16 +14,17 @@ payload:
   payloadName: pcheck
   butlerConfig: ${PIPELINES_CHECK_DIR}/DATA_REPO/butler.yaml
   inCollection: HSC/calib,HSC/raw/all,refcats
-  outCollection: "u/${USER}/pipelines_check/{timestamp}"
+  output: "u/${USER}/pipelines_check"
+  outCollection: "{output}/{timestamp}"
   dataQuery: exposure=903342 AND detector=10
 
 pipetask:
   pipetaskInit:
-    runQuantumCommand: "${CTRL_MPEXEC_DIR}/bin/pipetask --long-log run -b {butlerConfig} -i {inCollection} --output-run {outCollection} --init-only --skip-existing --register-dataset-types --qgraph {qgraphFile} --clobber-partial-outputs --no-versions"
+    runQuantumCommand: "${CTRL_MPEXEC_DIR}/bin/pipetask --long-log run -b {butlerConfig} -i {inCollection} --output {output} --output-run {outCollection} --init-only --skip-existing --register-dataset-types --qgraph {qgraphFile} --clobber-partial-outputs --no-versions"
   assembleCoadd:
     requestMemory: 8192
 
 wmsServiceClass: lsst.ctrl.bps.wms.htcondor.htcondor_service.HTCondorService
 clusterAlgorithm: lsst.ctrl.bps.quantum_clustering_funcs.single_quantum_clustering
 createQuantumGraph: '${CTRL_MPEXEC_DIR}/bin/pipetask qgraph -d "{dataQuery}" -b {butlerConfig} -i {inCollection} -p {pipelineYaml} -q {qgraphFile} --qgraph-dot {qgraphFile}.dot'
-runQuantumCommand: "${CTRL_MPEXEC_DIR}/bin/pipetask --long-log run -b {butlerConfig} -i {inCollection} --output-run {outCollection} --extend-run --skip-init-writes --qgraph {qgraphFile} --clobber-partial-outputs --no-versions"
+runQuantumCommand: "${CTRL_MPEXEC_DIR}/bin/pipetask --long-log run -b {butlerConfig} -i {inCollection} --output {output} --output-run {outCollection} --extend-run --skip-init-writes --qgraph {qgraphFile} --clobber-partial-outputs --no-versions"

--- a/doc/lsst.ctrl.bps/quickstart.rst
+++ b/doc/lsst.ctrl.bps/quickstart.rst
@@ -367,8 +367,10 @@ Supported settings
 
        pipetask:
          pipetask_init:
-           runQuantumCommand: "${CTRL_MPEXEC_DIR}/bin/pipetask --long-log run -b {butlerConfig} -i {inCollection} --output-run {outCollection} --init-only --skip-existing --register-dataset-types --qgraph {qgraphFile} --no-versions"
+           runQuantumCommand: "${CTRL_MPEXEC_DIR}/bin/pipetask --long-log run -b {butlerConfig} -i {inCollection} --output {output} --output-run {outCollection} --init-only --skip-existing --register-dataset-types --qgraph {qgraphFile} --no-versions"
            requestMemory: 2048
+
+    The above example command uses both ``--output`` and ``--output-run``.  The ``--output`` option creates the Chained collection if it doesn't already exist.  The ``--output-run`` option saves the unique Run collection that is also passed to all other compute jobs (i.e., one Run collection per submission).  If using both here, must include both ``--output`` and ``--output-run`` in the other ``runQuantumCommand``.
 
 **templateDataId**
     Template to use when creating job names (and HTCondor plugin then uses for

--- a/doc/lsst.ctrl.bps/quickstart.rst
+++ b/doc/lsst.ctrl.bps/quickstart.rst
@@ -367,10 +367,10 @@ Supported settings
 
        pipetask:
          pipetask_init:
-           runQuantumCommand: "${CTRL_MPEXEC_DIR}/bin/pipetask --long-log run -b {butlerConfig} -i {inCollection} --output {output} --output-run {outCollection} --init-only --skip-existing --register-dataset-types --qgraph {qgraphFile} --no-versions"
+           runQuantumCommand: "${CTRL_MPEXEC_DIR}/bin/pipetask --long-log run -b {butlerConfig} -i {inCollection} --output {output} --output-run {outCollection} --init-only --register-dataset-types --qgraph {qgraphFile} --clobber-partial-outputs --no-versions"
            requestMemory: 2048
 
-    The above example command uses both ``--output`` and ``--output-run``.  The ``--output`` option creates the Chained collection if it doesn't already exist.  The ``--output-run`` option saves the unique Run collection that is also passed to all other compute jobs (i.e., one Run collection per submission).  If using both here, must include both ``--output`` and ``--output-run`` in the other ``runQuantumCommand``.
+    The above example command uses both ``--output`` and ``--output-run``.  The ``--output`` option creates the chained collection if necessary and defines it to include both the ``--input`` and ``--output-run`` collections.  The ``--output-run`` option saves the unique run collection that is also passed to all other compute jobs (i.e., one run collection per submission).  If using both here, must include both ``--output`` and ``--output-run`` in the other ``runQuantumCommand``.
 
 **templateDataId**
     Template to use when creating job names (and HTCondor plugin then uses for


### PR DESCRIPTION
Using both --output and --output-run in the runQuantumCommands
will have pipetask create the Chained collection and all compute
jobs will share the same Run collection.  Modified example yaml
file and updated quickstart guide.

Note:  Overall documentation improvement covered in other ticket,
so just followed current documentation style for these changes. 