### PR TITLE
DM-27666: Remove path from qgraph filename in command line.

### DIFF
--- a/doc/lsst.ctrl.bps/quickstart.rst
+++ b/doc/lsst.ctrl.bps/quickstart.rst
@@ -383,6 +383,11 @@ Supported settings
 
        wmsServiceClass: lsst.ctrl.bps.wms.htcondor.htcondor_service.HTCondorService  # HTCondor
 
+**bpsUseShared**
+    Whether to put full submit-time path to QuantumGraph file in command line
+    because the WMS plugin requires shared filesystem.  Defaults to False.
+    HTCondor and Pegasus plugins do not need this value.
+
 Reserved keywords
 ^^^^^^^^^^^^^^^^^
 

--- a/python/lsst/ctrl/bps/transform.py
+++ b/python/lsst/ctrl/bps/transform.py
@@ -220,7 +220,9 @@ def create_command(config, label, qgraph_file):
     command : `str`
         String containing command line.
     """
-    search_opt = {"curvals": {"curr_pipetask": label, "qgraphFile": qgraph_file}, "required": False}
+    search_opt = {"curvals": {"curr_pipetask": label,
+                              "qgraphFile": os.path.basename(qgraph_file)},
+                  "required": False}
     found, command = config.search("runQuantumCommand", opt=search_opt)
     # Allow older Exec Args separation.
     if not found:

--- a/python/lsst/ctrl/bps/transform.py
+++ b/python/lsst/ctrl/bps/transform.py
@@ -220,9 +220,17 @@ def create_command(config, label, qgraph_file):
     command : `str`
         String containing command line.
     """
-    search_opt = {"curvals": {"curr_pipetask": label,
-                              "qgraphFile": os.path.basename(qgraph_file)},
+    search_opt = {"curvals": {"curr_pipetask": label},
                   "required": False}
+
+    # Temporary check until lazy command creation in DM-27009
+    found, use_shared = config.search("bpsUseShared", opt=search_opt)
+    if found and use_shared:
+        qfile = qgraph_file
+    else:
+        qfile = os.path.basename(qgraph_file)
+
+    search_opt["curvals"]["qgraphFile"] = qfile
     found, command = config.search("runQuantumCommand", opt=search_opt)
     # Allow older Exec Args separation.
     if not found:

--- a/python/lsst/ctrl/bps/wms/htcondor/lssthtc.py
+++ b/python/lsst/ctrl/bps/wms/htcondor/lssthtc.py
@@ -79,6 +79,7 @@ HTC_VALID_JOB_KEYS = {
     "universe",
     "executable",
     "arguments",
+    "environment",
     "log",
     "error",
     "output",


### PR DESCRIPTION
This is the short-term fix ticket that fixes a bug keeping htcondor jobs from using the qgraph file it staged.  With the bug, it worked when there was a shared filesystem such that the job could access it in the submit location.  The long-term changes to not put it in the command line at all in the GenericWorkflow, but instead leaving it for the WMS plugin to handle is in a different ticket.  Tested with htcondor and pegasus plugins.  

While discussing this change with the folks who needed it because they don't have a shared filesystem, discovered that setting the environment in the htcondor section of the BPS yaml also wasn't working.  Since simple fix, just made the change in this ticket too.