### PR TITLE
DM-27675: Add ability to pass single large QuantumGraph to jobs.

### DIFF
--- a/doc/lsst.ctrl.bps/quickstart.rst
+++ b/doc/lsst.ctrl.bps/quickstart.rst
@@ -493,7 +493,7 @@ BPS can be configured to either create per-job QuantumGraph files or use the
 single full QuantumGraph file plus node numbers for each job. The default is
 using per-job QuantumGraph files.
 
-To use full QuantumGraph file, the submit yaml must set `whenSaveJobQgraph` to
+To use full QuantumGraph file, the submit YAML must set `whenSaveJobQgraph` to
 "NEVER" and the ``pipetask run`` command must include ``--qgraph-id {qgraphId}
 --qgraph-node-id {qgraphNodeId}``.  For example:
 

--- a/doc/lsst.ctrl.bps/quickstart.rst
+++ b/doc/lsst.ctrl.bps/quickstart.rst
@@ -265,6 +265,10 @@ you can just do the following no matter if using HTCondor or Pegasus WMS plugin:
 BPS configuration file
 ----------------------
 
+The configuration file is in YAML format.  One particular YAML
+syntax to be mindful about is that boolean values must be all
+lowercase.
+
 Configuration file can include other configuration files using
 ``includeConfigs`` with YAML array syntax. For example
 
@@ -443,6 +447,15 @@ Supported settings
     because the WMS plugin requires shared filesystem.  Defaults to False.
     HTCondor and Pegasus plugins do not need this value.
 
+**whenSaveJobQgraph**
+    When to output job QuantumGraph files (default = TRANSFORM).
+
+    * NEVER = all jobs will use full QuantumGraph file. (Warning: make sure
+      runQuantumCommand has ``--qgraph-id {qgraphId} --qgraph-node-id {qgraphNodeId}``.)
+    * TRANSFORM = Output QuantumGraph files after creating GenericWorkflow.
+    * PREPARE = QuantumGraph files are output after creating WMS submission.
+
+
 Reserved keywords
 ^^^^^^^^^^^^^^^^^
 
@@ -451,6 +464,14 @@ Reserved keywords
 
     Such a file is an alternative way to describe a science pipeline.
     However, contrary to YAML specification, it is currently not portable.
+
+**qgraphId**
+    Internal ID for the full QuantumGraph (passed as ``--qgraph-id`` on pipetask command line).
+
+**qgraphNodeId**
+    Comma-separated list of internal QuantumGraph node numbers to be
+    executed from the full QuantumGraph (passed as ``--qgraph-node-id`` on pipetask
+    command line).
 
 **timestamp**
     Created automatically by BPS at submit time that can be used in the user
@@ -462,6 +483,33 @@ Reserved keywords
    Any values shown in the example configuration file, but not covered in this
    section are examples of user-defined variables (e.g. ``inCollection``) and
    are not required by BPS.
+
+.. _job-qgraph-files:
+
+QuantumGraph Files
+------------------
+
+BPS can be configured to either create per-job QuantumGraph files or use the
+single full QuantumGraph file plus node numbers for each job. The default is
+using per-job QuantumGraph files.
+
+To use full QuantumGraph file, the submit yaml must set `whenSaveJobQgraph` to
+"NEVER" and the ``pipetask run`` command must include ``--qgraph-id {qgraphId}
+--qgraph-node-id {qgraphNodeId}``.  For example:
+
+.. code::
+
+    whenSaveJobQgraph: "NEVER"
+    runQuantumCommand: "${CTRL_MPEXEC_DIR}/bin/pipetask --long-log run -b {butlerConfig} -i {inCollection} --output {output} --output-run {outCollection} --extend-run --skip-init-writes --qgraph {qgraphFile} --qgraph-id {qgraphId} --qgraph-node-id {qgraphNodeId} --clobber-partial-outputs --no-versions"
+
+-- warning::
+
+   Do not modify the QuantumGraph options in pipetaskInit's runQuantumCommand.  It needs the entire QuantumGraph.
+
+-- note::
+
+   If running on a system with a shared filesystem, you'll more than likely want to also set bpsUseShared
+   to true.
 
 .. _bps-troubleshooting:
 

--- a/python/lsst/ctrl/bps/bps_utils.py
+++ b/python/lsst/ctrl/bps/bps_utils.py
@@ -36,6 +36,7 @@ class WhenToSaveQuantumGraphs(Enum):
     TRANSFORM = 2
     PREPARE = 3
     SUBMIT = 4
+    NEVER = 5    # Always use full QuantumGraph.
 
 
 @contextlib.contextmanager
@@ -83,21 +84,23 @@ def create_job_quantum_graph_filename(job, out_prefix=None):
     return full_filename
 
 
-def save_qg_subgraph(qgraph, out_filename):
+def save_qg_subgraph(qgraph, out_filename, node_ids=None):
     """Save subgraph to file.
 
     Parameters
     ----------
-    qgraph : `~lsst.pipe.base.graph.QuantumGraph`
+    qgraph : `~lsst.pipe.base.QuantumGraph`
         QuantumGraph to save.
     out_filename : `str`
         Name of the output file.
+    node_ids : `list` of `~lsst.pipe.base.NodeId`
+        NodeIds for the subgraph to save to file.
     """
     if not os.path.exists(out_filename):
         _LOG.debug("Saving QuantumGraph with %d nodes to %s", len(qgraph), out_filename)
-        if len(os.path.dirname(out_filename)) > 0:
-            os.makedirs(os.path.dirname(out_filename), exist_ok=True)
-        with open(out_filename, "wb") as fh:
-            qgraph.save(fh)
+        if node_ids is None:
+            qgraph.saveUri(out_filename)
+        else:
+            qgraph.subset(qgraph.getQuantumNodeByNodeId(nid) for nid in node_ids).saveUri(out_filename)
     else:
         _LOG.debug("Skipping saving QuantumGraph to %s because already exists.", out_filename)

--- a/python/lsst/ctrl/bps/clustered_quantum_graph.py
+++ b/python/lsst/ctrl/bps/clustered_quantum_graph.py
@@ -35,7 +35,7 @@ class ClusteredQuantumGraph(networkx.DiGraph):
     use API over totally minimized memory usage.
     """
 
-    def add_cluster(self, name, node_ids, label=None):
+    def add_cluster(self, name, node_ids, label=None, tags=None):
         """Add a cluster of quanta as a node in the graph.
 
         Parameters
@@ -46,8 +46,10 @@ class ClusteredQuantumGraph(networkx.DiGraph):
             NodeIds for QuantumGraph subset.
         label : `str`, optional
             Label for the cluster.  Can be used in grouping clusters.
+        tags : `dict` [`str`, `Any`], optional
+            Arbitrary tags for the cluster.
         """
-        self.add_node(name, qgraph_node_ids=node_ids, label=label)
+        self.add_node(name, qgraph_node_ids=node_ids, label=label, tags=tags)
 
     def add_node(self, node_for_adding, **attr):
         """Override add_node function to ensure that nodes are limited

--- a/python/lsst/ctrl/bps/clustered_quantum_graph.py
+++ b/python/lsst/ctrl/bps/clustered_quantum_graph.py
@@ -59,7 +59,7 @@ class ClusteredQuantumGraph(networkx.DiGraph):
         ----------
         node_for_adding : `str` or `list` of `~lsst.pipe.base.NodeId`
             Name of cluster or cluster data (list of NodeIds).
-        attr :
+        attr : keyword arguments, optional
             Attributes to be saved with node in graph.
         """
         if isinstance(node_for_adding, list):
@@ -67,13 +67,16 @@ class ClusteredQuantumGraph(networkx.DiGraph):
             attr["qgraph_node_ids"] = node_for_adding
         elif "qgraph_node_ids" in attr:
             if not isinstance(attr["qgraph_node_ids"], list):
-                raise RuntimeError("Invalid type for qgraph_node_ids attribute.")
+                raise RuntimeError(f"Invalid type {type(attr['qgraph_node_ids'])}"
+                                   " for qgraph_node_ids attribute; should be list.")
             name = node_for_adding
         else:
             raise RuntimeError("Missing qgraph_node_ids attribute.")
 
         if "label" not in attr:
             attr["label"] = None
+        if "tags" not in attr:
+            attr["tags"] = None
         super().add_node(name, **attr)
 
     def add_nodes_from(self, nodes_for_adding, **attr):

--- a/python/lsst/ctrl/bps/generic_workflow.py
+++ b/python/lsst/ctrl/bps/generic_workflow.py
@@ -55,7 +55,7 @@ class GenericWorkflowFile:
         self.dest_uri = dest_uri
         self.logical_file_name = logical_file_name
 
-    __slots__ = ('name', 'wms_transfer', 'dataset_ref', 'src_uri', 'dest_uri', 'logical_file_name')
+    __slots__ = ("name", "wms_transfer", "dataset_ref", "src_uri", "dest_uri", "logical_file_name")
 
     def __hash__(self):
         return hash(self.name)
@@ -71,6 +71,7 @@ class GenericWorkflowJob:
     """
     name: str
     label: Optional[str]
+    tags: Optional[str]
     cmdline: Optional[str]
     request_memory: Optional[int]    # MB
     request_cpus: Optional[int]       # cores
@@ -98,6 +99,7 @@ class GenericWorkflowJob:
     def __init__(self, name: str):
         self.name = name
         self.label = None
+        self.tags = None
         self.cmdline = None
         self.request_memory = None
         self.request_cpus = None
@@ -121,11 +123,11 @@ class GenericWorkflowJob:
         self.qgraph_node_ids = None
         self.quanta_summary = ""
 
-    __slots__ = ('name', 'label', 'mail_to', 'when_to_mail', 'cmdline', 'request_memory', 'request_cpus',
-                 'request_disk', 'request_walltime', 'compute_site', 'environment', 'number_of_retries',
-                 'retry_unless_exit', 'abort_on_value', 'abort_return_value', 'priority',
-                 'category', 'pre_cmdline', 'post_cmdline', 'profile', 'attrs',
-                 'quantum_graph', 'qgraph_node_ids', 'quanta_summary')
+    __slots__ = ("name", "label", "tags", "mail_to", "when_to_mail", "cmdline", "request_memory",
+                 "request_cpus", "request_disk", "request_walltime", "compute_site", "environment",
+                 "number_of_retries", "retry_unless_exit", "abort_on_value", "abort_return_value",
+                 "priority", "category", "pre_cmdline", "post_cmdline", "profile", "attrs",
+                 "quantum_graph", "qgraph_node_ids", "quanta_summary")
 
     def __hash__(self):
         return hash(self.name)
@@ -280,7 +282,7 @@ class GenericWorkflow(nx.DiGraph):
         job : `~lsst.ctrl.bps.generic_workflow.GenericWorkflowJob`
             Job matching given job_name.
         """
-        return self.nodes[job_name]['job']
+        return self.nodes[job_name]["job"]
 
     def del_job(self, job_name: str):
         """Delete job from generic workflow leaving connected graph.
@@ -308,7 +310,7 @@ class GenericWorkflow(nx.DiGraph):
         files : `~lsst.ctrl.bps.generic_workflow.GenericWorkflowFile` or `list`
             File object(s) to be added as inputs to the specified job.
         """
-        job_inputs = self.nodes[job_name]['inputs']
+        job_inputs = self.nodes[job_name]["inputs"]
         for file in iterable(files):
             # Save the central copy
             if file.name not in self._files:
@@ -350,7 +352,7 @@ class GenericWorkflow(nx.DiGraph):
         inputs : `list` of `~lsst.ctrl.bps.generic_workflow.GenericWorkflowFile`
             Input files for the given job.
         """
-        job_inputs = self.nodes[job_name]['inputs']
+        job_inputs = self.nodes[job_name]["inputs"]
         inputs = []
         for file_name in job_inputs:
             file = self._files[file_name]
@@ -371,7 +373,7 @@ class GenericWorkflow(nx.DiGraph):
         files : `list` of `~lsst.ctrl.bps.generic_workflow.GenericWorkflowFile`
             File objects to be added as outputs for specified job.
         """
-        job_outputs = self.nodes[job_name]['outputs']
+        job_outputs = self.nodes[job_name]["outputs"]
         for file in files:
             # Save the central copy
             if file.name not in self._files:
@@ -399,7 +401,7 @@ class GenericWorkflow(nx.DiGraph):
         outputs : `list` of `~lsst.ctrl.bps.generic_workflow.GenericWorkflowFile`
             Output files for the given job.
         """
-        job_outputs = self.nodes[job_name]['outputs']
+        job_outputs = self.nodes[job_name]["outputs"]
         outputs = []
         for file_name in job_outputs:
             file = self._files[file_name]
@@ -421,13 +423,13 @@ class GenericWorkflow(nx.DiGraph):
             Which visualization format to use.  It defaults to the format for
             the dot program.
         """
-        draw_funcs = {'dot': draw_networkx_dot}
+        draw_funcs = {"dot": draw_networkx_dot}
         if format_ in draw_funcs:
             draw_funcs[format_](self, stream)
         else:
             raise RuntimeError(f"Unknown draw format ({format_}")
 
-    def save(self, stream, format_='pickle'):
+    def save(self, stream, format_="pickle"):
         """Save the generic workflow in a format that is loadable.
 
         Parameters
@@ -439,7 +441,7 @@ class GenericWorkflow(nx.DiGraph):
         format_ : `str`, optional
             Format in which to write the data. It defaults to pickle format.
         """
-        if format_ == 'pickle':
+        if format_ == "pickle":
             nx.write_gpickle(self, stream)
         else:
             raise RuntimeError(f"Unknown format ({format_})")
@@ -462,7 +464,7 @@ class GenericWorkflow(nx.DiGraph):
         generic_workflow : `~lsst.ctrl.bps.generic_workflow.GenericWorkflow`
             Generic workflow loaded from the given stream
         """
-        if format_ == 'pickle':
+        if format_ == "pickle":
             return nx.read_gpickle(stream)
 
         raise RuntimeError(f"Unknown format ({format_})")

--- a/python/lsst/ctrl/bps/generic_workflow.py
+++ b/python/lsst/ctrl/bps/generic_workflow.py
@@ -91,6 +91,7 @@ class GenericWorkflowJob:
     attrs: Optional[dict]
     environment: Optional[dict]
     quantum_graph: Optional[QuantumGraph]
+    qgraph_node_ids: Optional[list]
     quanta_summary: Optional[str]
 
     # As of python 3.7.8, can't use __slots__ if give default values, so writing own __init__
@@ -117,13 +118,14 @@ class GenericWorkflowJob:
         self.attrs = {}
         self.environment = {}
         self.quantum_graph = None
+        self.qgraph_node_ids = None
         self.quanta_summary = ""
 
     __slots__ = ('name', 'label', 'mail_to', 'when_to_mail', 'cmdline', 'request_memory', 'request_cpus',
                  'request_disk', 'request_walltime', 'compute_site', 'environment', 'number_of_retries',
                  'retry_unless_exit', 'abort_on_value', 'abort_return_value', 'priority',
                  'category', 'pre_cmdline', 'post_cmdline', 'profile', 'attrs',
-                 'quantum_graph', 'quanta_summary')
+                 'quantum_graph', 'qgraph_node_ids', 'quanta_summary')
 
     def __hash__(self):
         return hash(self.name)

--- a/python/lsst/ctrl/bps/pre_transform.py
+++ b/python/lsst/ctrl/bps/pre_transform.py
@@ -112,7 +112,7 @@ def execute(command, filename):
         )
         buffer = os.read(process.stdout.fileno(), buffer_size).decode()
         while process.poll is None or buffer:
-            print(buffer, end='', file=fh)
+            print(buffer, end="", file=fh)
             _LOG.info(buffer)
             buffer = os.read(process.stdout.fileno(), buffer_size).decode()
         process.stdout.close()
@@ -178,8 +178,7 @@ def read_quantum_graph(qgraph_filename):
     `RuntimeError`
         If the QuantumGraph contains 0 Quanta
     """
-    with open(qgraph_filename, "rb") as fh:
-        qgraph = QuantumGraph.load(fh, DimensionUniverse())
+    qgraph = QuantumGraph.loadUri(qgraph_filename, DimensionUniverse())
     if len(qgraph) == 0:
         raise RuntimeError("QuantumGraph is empty")
     return qgraph

--- a/python/lsst/ctrl/bps/prepare.py
+++ b/python/lsst/ctrl/bps/prepare.py
@@ -53,9 +53,8 @@ def prepare(config, generic_workflow, out_prefix):
 
     # Save QuantumGraphs.
     # (putting after call to prepare so don't write a bunch of files if prepare fails)
-    found, when_to_save_job_qgraph = config.search("whenSaveJobQgraph",
-                                                   {"default": WhenToSaveQuantumGraphs.TRANSFORM})
-    if found and when_to_save_job_qgraph == WhenToSaveQuantumGraphs.PREPARE:
+    found, when_save = config.search("whenSaveJobQgraph", {"default": WhenToSaveQuantumGraphs.TRANSFORM.name})
+    if found and WhenToSaveQuantumGraphs[when_save.upper()] == WhenToSaveQuantumGraphs.PREPARE:
         for job_name in generic_workflow.nodes():
             job = generic_workflow.get_job(job_name)
             save_qg_subgraph(job.quantum_graph, create_job_quantum_graph_filename(job, out_prefix))

--- a/python/lsst/ctrl/bps/quantum_clustering_funcs.py
+++ b/python/lsst/ctrl/bps/quantum_clustering_funcs.py
@@ -48,17 +48,19 @@ def single_quantum_clustering(config, qgraph, name):
         ClusteredQuantumGraph with single quantum per cluster created from
         given QuantumGraph.
     """
-    clustered_quantum = ClusteredQuantumGraph(name=name)
+    clustered_quantum = ClusteredQuantumGraph(name=name, qgraph=qgraph)
 
     # Save mapping of quantum nodeNumber to name so don't have to create it multiple times.
     number_to_name = {}
 
     # Create cluster of single quantum.
     for quantum_node in qgraph:
-        subgraph = qgraph.subset(quantum_node)
         label = quantum_node.taskDef.label
-        found, template = config.search('templateDataId', opt={'curvals': {'curr_pipetask': label},
-                                                               'replaceVars': False})
+        number = quantum_node.nodeId.number
+        data_id = quantum_node.quantum.dataId
+
+        found, template = config.search("templateDataId", opt={"curvals": {"curr_pipetask": label},
+                                                               "replaceVars": False})
         if found:
             template = "{node_number}_{label}_" + template
         else:
@@ -67,18 +69,25 @@ def single_quantum_clustering(config, qgraph, name):
         # Note: Can't quite reuse lsst.daf.butler.core.fileTemplates.FileTemplate as don't
         # want to require datasetType (and run) in the template.  Use defaultdict to handle
         # the missing values in template.
-        data_id = quantum_node.quantum.dataId
-        info = defaultdict(lambda: '', {k: data_id.get(k) for k in data_id.graph.names})
-        info['label'] = label
-        info['node_number'] = quantum_node.nodeId.number
+
+        # Gather info for name template into a dictionary.
+        info = defaultdict(lambda: "", {k: data_id.get(k) for k in data_id.graph.names})
+        info["label"] = label
+        info["node_number"] = number
         _LOG.debug("template = %s", template)
         _LOG.debug("info for template = %s", info)
-        name = template.format_map(info)
-        name = re.sub('_+', '_', name)
-        _LOG.debug("template name = %s", name)
-        number_to_name[quantum_node.nodeId.number] = name
 
-        clustered_quantum.add_cluster(name, subgraph, label)
+        # Use dictionary plus template format string to create name.
+        name = template.format_map(info)
+        name = re.sub("_+", "_", name)
+        _LOG.debug("template name = %s", name)
+
+        # Save mapping for use when creating dependencies.
+        number_to_name[number] = name
+
+        # Add cluster to the ClusteredQuantumGraph.
+        # Saving NodeId instead of number because QuantumGraph API requires it.
+        clustered_quantum.add_cluster(name, [quantum_node.nodeId], label)
 
     # Add cluster dependencies.
     for quantum_node in qgraph:

--- a/python/lsst/ctrl/bps/quantum_clustering_funcs.py
+++ b/python/lsst/ctrl/bps/quantum_clustering_funcs.py
@@ -71,14 +71,15 @@ def single_quantum_clustering(config, qgraph, name):
         # the missing values in template.
 
         # Gather info for name template into a dictionary.
-        info = defaultdict(lambda: "", {k: data_id.get(k) for k in data_id.graph.names})
+        info = data_id.to_simple()
         info["label"] = label
         info["node_number"] = number
         _LOG.debug("template = %s", template)
         _LOG.debug("info for template = %s", info)
 
         # Use dictionary plus template format string to create name.
-        name = template.format_map(info)
+        # To avoid key errors from generic patterns, use defaultdict
+        name = template.format_map(defaultdict(lambda: "", info))
         name = re.sub("_+", "_", name)
         _LOG.debug("template name = %s", name)
 
@@ -87,7 +88,7 @@ def single_quantum_clustering(config, qgraph, name):
 
         # Add cluster to the ClusteredQuantumGraph.
         # Saving NodeId instead of number because QuantumGraph API requires it.
-        clustered_quantum.add_cluster(name, [quantum_node.nodeId], label)
+        clustered_quantum.add_cluster(name, [quantum_node.nodeId], label, info)
 
     # Add cluster dependencies.
     for quantum_node in qgraph:

--- a/python/lsst/ctrl/bps/transform.py
+++ b/python/lsst/ctrl/bps/transform.py
@@ -51,8 +51,8 @@ def transform(config, clustered_quantum_graph, prefix):
     generic_workflow : `~lsst.ctrl.bps.generic_workflow.GenericWorkflow`
         The generic workflow transformed from the clustered quantum graph.
     """
-    if 'name' in clustered_quantum_graph.graph and clustered_quantum_graph.graph['name'] is not None:
-        name = clustered_quantum_graph.graph['name']
+    if "name" in clustered_quantum_graph.graph and clustered_quantum_graph.graph["name"] is not None:
+        name = clustered_quantum_graph.graph["name"]
     else:
         _, name = config.search("uniqProcName", opt={"required": True})
 
@@ -95,6 +95,8 @@ def group_clusters_into_jobs(clustered_quanta_graph, name):
                    len(data["qgraph_node_ids"]), data["label"], data["qgraph_node_ids"][:4])
         job = GenericWorkflowJob(node_name)
         job.qgraph_node_ids = data["qgraph_node_ids"]
+        if "tags" in data:
+            job.tags = data["tags"]
         if "label" in data:
             job.label = data["label"]
         generic_workflow.add_job(job)
@@ -409,8 +411,8 @@ def add_workflow_attributes(config, generic_workflow):
     for job_name in generic_workflow:
         job = generic_workflow.get_job(job_name)
         if job.quanta_summary:
-            for job_summary_part in job.quanta_summary.split(';'):
-                (label, cnt) = job_summary_part.split(':')
+            for job_summary_part in job.quanta_summary.split(";"):
+                (label, cnt) = job_summary_part.split(":")
                 if label not in run_quanta_counts:
                     run_quanta_counts[label] = 0
                 run_quanta_counts[label] += int(cnt)

--- a/python/lsst/ctrl/bps/transform.py
+++ b/python/lsst/ctrl/bps/transform.py
@@ -217,7 +217,7 @@ def create_command(config, gwjob, gwfile):
         Bps configuration.
     gwjob : `~lsst.ctrl.bps.generic_workflow.GenericWorkflowJob`
         Job for which to create command line.
-    qwfile : `~lsst.ctrl.bps.generic_workflow.GenericWorkflowFile`
+    gwfile : `~lsst.ctrl.bps.generic_workflow.GenericWorkflowFile`
         File that will contain the QuantumGraph.
     """
     search_opt = {"curvals": {"curr_pipetask": gwjob.label}, "required": False}


### PR DESCRIPTION
pipetask has ability to take full QuantumGraph and list of node numbers to run.  Code for this ticket added the ability to for bps to handle that as well.  

QuantumGraph also had Uri versions of save and load functions added a while back.  Switched bps code to use those.

Calling subset to create the ClusteredQuantumGraph runs longer and uses more memory than just storing a list of NodeIds.  So changed the internal representation.   This change removed dataIds from appearing in the GenericWorkflow which was being used by someone to do late job resource estimation.  While longer term this better job resource estimation should go earlier in the process and not in a WMS plugin, decided to try to provide this information until the earlier estimation capabilities are in place.  To this end, job tags were added which include the dataId values for the current case where one job equals one Quantum. 

Also made more of the quotation marks consistent across the code (in files already modified for this ticket).