### PR TITLE
DM-29953: Fix TypeError on dataId.

### DIFF
--- a/python/lsst/ctrl/bps/quantum_clustering_funcs.py
+++ b/python/lsst/ctrl/bps/quantum_clustering_funcs.py
@@ -71,7 +71,7 @@ def single_quantum_clustering(config, qgraph, name):
         # the missing values in template.
 
         # Gather info for name template into a dictionary.
-        info = data_id.to_simple()
+        info = data_id.byName()
         info["label"] = label
         info["node_number"] = number
         _LOG.debug("template = %s", template)


### PR DESCRIPTION
Code assumed dataId.to_simple() would return a dict.  The
type of dataId changed so this is no longer true.