### PR TITLE
DM-31970:  Fix AttributeError and bps report of older runs.

### DIFF
--- a/doc/changes/DM-31970.bugfix.rst
+++ b/doc/changes/DM-31970.bugfix.rst
@@ -1,0 +1,2 @@
+* Fix AttributeError during submission if explicitly not using execution butler.
+* Fix bps report summary PermissionsError caused by certain runs with previous version in queue.

--- a/python/lsst/ctrl/bps/generic_workflow.py
+++ b/python/lsst/ctrl/bps/generic_workflow.py
@@ -346,12 +346,13 @@ class GenericWorkflow(DiGraph):
 
         # Final is separate
         final = self.get_final()
-        if isinstance(final, GenericWorkflow):
-            for job_name in final:
-                gwjob = final.get_job(job_name)
-                jcounts[gwjob.label] += 1
-        else:
-            jcounts[final.label] += 1
+        if final:
+            if isinstance(final, GenericWorkflow):
+                for job_name in final:
+                    gwjob = final.get_job(job_name)
+                    jcounts[gwjob.label] += 1
+            else:
+                jcounts[final.label] += 1
 
         return jcounts
 

--- a/python/lsst/ctrl/bps/wms/htcondor/htcondor_service.py
+++ b/python/lsst/ctrl/bps/wms/htcondor/htcondor_service.py
@@ -990,7 +990,7 @@ def _get_run_summary(job):
         Number of jobs per PipelineTask label in approximate pipeline order.
         Format: <label>:<count>[;<label>:<count>]+
     """
-    summary = job.get("bps_job_summary", None)
+    summary = job.get("bps_job_summary", job.get("bps_run_summary", None))
     if not summary:
         summary, _ = summary_from_dag(job["Iwd"])
         if not summary:


### PR DESCRIPTION
Both of these are backwards compatibility issues caused by DM-31887 changes.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
