### PR TITLE
DM-32220: Disable HTCondor auto-detection of output files

### DIFF
--- a/doc/changes/DM-32220.bugfix.rst
+++ b/doc/changes/DM-32220.bugfix.rst
@@ -1,0 +1,1 @@
+Disable HTCondor auto detection of files to copy back from jobs.

--- a/python/lsst/ctrl/bps/wms/htcondor/htcondor_service.py
+++ b/python/lsst/ctrl/bps/wms/htcondor/htcondor_service.py
@@ -390,6 +390,7 @@ class HTCondorWorkflow(BaseWmsWorkflow):
             "universe": "vanilla",
             "should_transfer_files": "YES",
             "when_to_transfer_output": "ON_EXIT_OR_EVICT",
+            "transfer_output_files": '""',  # Set to empty string to disable
             "transfer_executable": "False",
             "getenv": "True",
 

--- a/python/lsst/ctrl/bps/wms/htcondor/lssthtc.py
+++ b/python/lsst/ctrl/bps/wms/htcondor/lssthtc.py
@@ -148,6 +148,7 @@ HTC_VALID_JOB_KEYS = {
     "concurrency_limit",
     "transfer_executable",
     "transfer_input_files",
+    "transfer_output_files",
     "request_cpus",
     "request_memory",
     "request_disk",


### PR DESCRIPTION
to copy back from job.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
