### PR TITLE
DM-34959: Replace read_gpickle and write_gpickle in GenericWorkflow

### DIFF
--- a/doc/changes/DM-34959.misc.rst
+++ b/doc/changes/DM-34959.misc.rst
@@ -1,0 +1,1 @@
+Replace NetworkX functions that are being deprecated.

--- a/python/lsst/ctrl/bps/generic_workflow.py
+++ b/python/lsst/ctrl/bps/generic_workflow.py
@@ -28,11 +28,12 @@ __all__ = ["GenericWorkflow", "GenericWorkflowFile", "GenericWorkflowJob", "Gene
 import dataclasses
 import itertools
 import logging
+import pickle
 from collections import Counter
 from typing import Optional
 
 from lsst.utils.iteration import ensure_iterable
-from networkx import DiGraph, read_gpickle, topological_sort, write_gpickle
+from networkx import DiGraph, topological_sort
 from networkx.algorithms.dag import is_directed_acyclic_graph
 
 from .bps_draw import draw_networkx_dot
@@ -716,7 +717,7 @@ class GenericWorkflow(DiGraph):
             Format in which to write the data. It defaults to pickle format.
         """
         if format_ == "pickle":
-            write_gpickle(self, stream)
+            pickle.dump(self, stream)
         else:
             raise RuntimeError(f"Unknown format ({format_})")
 
@@ -739,7 +740,7 @@ class GenericWorkflow(DiGraph):
             Generic workflow loaded from the given stream
         """
         if format_ == "pickle":
-            return read_gpickle(stream)
+            return pickle.load(stream)
 
         raise RuntimeError(f"Unknown format ({format_})")
 


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
