### PR TITLE
DM-38418: Override get method in BpsConfig to make default value parameter work

### DIFF
--- a/doc/changes/DM-38418.api.rst
+++ b/doc/changes/DM-38418.api.rst
@@ -1,0 +1,1 @@
+Implement get() method in BpsConfig.

--- a/python/lsst/ctrl/bps/bps_config.py
+++ b/python/lsst/ctrl/bps/bps_config.py
@@ -131,6 +131,31 @@ class BpsConfig(Config):
         """
         return BpsConfig(self)
 
+    def get(self, key, default=""):
+        """Return the value for key if key is in the config, else default.
+
+        If default is not given, it defaults to an empty string.
+
+        Parameters
+        ----------
+        key : `str`
+            Key to look for in config.
+        default : Any, optional
+            Default value to return if the key is not in the config.
+
+        Returns
+        -------
+        val : Any
+            Value from config if found, default otherwise.
+
+        Notes
+        -----
+        The provided default value (an empty string) was chosen to maintain
+        the internal consistency with other methods of the class.
+        """
+        _, val = self.search(key, opt={"default": default})
+        return val
+
     def __getitem__(self, name):
         """Return the value from the config for the given name.
 

--- a/tests/test_bpsconfig.py
+++ b/tests/test_bpsconfig.py
@@ -66,6 +66,30 @@ class TestBpsConfigConstructor(unittest.TestCase):
             BpsConfig(sequence)
 
 
+class TestBpsConfigGet(unittest.TestCase):
+    def setUp(self):
+        self.config = BpsConfig({"foo": "bar"})
+
+    def tearDown(self):
+        pass
+
+    def testKeyExistsNoDefault(self):
+        """Test if the value is returned when the key is in the dictionary."""
+        self.assertEqual("bar", self.config.get("foo"))
+
+    def testKeyExistsDefaultProvided(self):
+        """Test if the value is returned when the key is in the dictionary."""
+        self.assertEqual("bar", self.config.get("foo", "qux"))
+
+    def testKeyMissingNoDefault(self):
+        """Test if the provided default is returned if the key is missing."""
+        self.assertEqual("", self.config.get("baz"))
+
+    def testKeyMissingDefaultProvided(self):
+        """Test if the custom default is returned if the key is missing."""
+        self.assertEqual("qux", self.config.get("baz", "qux"))
+
+
 class TestBpsConfigSearch(unittest.TestCase):
     def setUp(self):
         filename = os.path.join(TESTDIR, "data/config.yaml")


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
