### PR TITLE
DM-38469: Remove read_quantum_graph method.

### DIFF
--- a/doc/changes/DM-38469.removal.rst
+++ b/doc/changes/DM-38469.removal.rst
@@ -1,0 +1,1 @@
+Remove read_quantum_graph method as passing of butler repository's DimensionUniverse to QuantumGraph.loadUri() is no longer required.

--- a/doc/changes/README.rst
+++ b/doc/changes/README.rst
@@ -18,5 +18,4 @@ The ``<TYPE>`` should be one of:
 
 An example file name would therefore look like ``DM-30291.misc.rst``.
 
-You can test how the content will be integrated into the release notes by running ``towncrier --draft --version=V.vv``.
-``towncrier`` can be installed from PyPI or conda-forge.
+You can test how the content will be integrated into the release notes by running ``towncrier build --draft --version=V.vv`` in the package's top directory.  ``towncrier`` can be installed from PyPI or conda-forge.

--- a/python/lsst/ctrl/bps/pre_transform.py
+++ b/python/lsst/ctrl/bps/pre_transform.py
@@ -31,7 +31,6 @@ import shutil
 import subprocess
 
 from lsst.ctrl.bps.bps_utils import _create_execution_butler
-from lsst.daf.butler import Butler
 from lsst.pipe.base.graph import QuantumGraph
 from lsst.utils import doImport
 from lsst.utils.logging import VERBOSE
@@ -106,7 +105,7 @@ def acquire_quantum_graph(config, out_prefix=""):
 
     _LOG.info("Reading quantum graph from '%s'", qgraph_filename)
     with time_this(log=_LOG, level=logging.INFO, prefix=None, msg="Completed reading quantum graph"):
-        qgraph = read_quantum_graph(qgraph_filename, config["butlerConfig"])
+        qgraph = QuantumGraph.loadUri(qgraph_filename)
 
     if when_create.upper() == "QGRAPH_CMDLINE":
         if not os.path.exists(execution_butler_dir):
@@ -189,36 +188,6 @@ def create_quantum_graph(config, out_prefix=""):
             f"Check {out} for more details."
         )
     return qgraph_filename
-
-
-def read_quantum_graph(qgraph_filename, butler_uri):
-    """Read the QuantumGraph from disk.
-
-    Parameters
-    ----------
-    qgraph_filename : `str`
-        Name of file containing QuantumGraph to be used for workflow
-        generation.
-    butler_uri : `str`
-        Location of butler repository that can be used to create a
-        butler object.
-
-    Returns
-    -------
-    qgraph : `lsst.pipe.base.graph.QuantumGraph`
-        The QuantumGraph read from a file.
-
-    Raises
-    ------
-    RuntimeError
-        If the QuantumGraph contains 0 Quanta.
-    """
-    # Get the DimensionUniverse from the butler repository
-    butler = Butler(butler_uri, writeable=False)
-    qgraph = QuantumGraph.loadUri(qgraph_filename, butler.registry.dimensions)
-    if len(qgraph) == 0:
-        raise RuntimeError("QuantumGraph is empty")
-    return qgraph
 
 
 def cluster_quanta(config, qgraph, name):

--- a/python/lsst/ctrl/bps/quantum_clustering_funcs.py
+++ b/python/lsst/ctrl/bps/quantum_clustering_funcs.py
@@ -55,7 +55,6 @@ def single_quantum_clustering(config, qgraph, name):
         name=name,
         qgraph=qgraph,
         qgraph_filename=config[".bps_defined.runQgraphFile"],
-        butler_uri=config["butlerConfig"],
     )
 
     # Save mapping of quantum nodeNumber to name so don't have to create it
@@ -176,7 +175,6 @@ def dimension_clustering(config, qgraph, name):
         name=name,
         qgraph=qgraph,
         qgraph_filename=config[".bps_defined.runQgraphFile"],
-        butler_uri=config["butlerConfig"],
     )
 
     # save mapping in order to create dependencies later


### PR DESCRIPTION
Call QuantumGraph.loadUri() directly as passing of butler repository's DimensionUniverse is no longer needed.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
