### PR TITLE
DM-41043: Fix import of Config from butler

### DIFF
--- a/tests/test_bpsconfig.py
+++ b/tests/test_bpsconfig.py
@@ -29,7 +29,7 @@ import unittest
 
 import yaml
 from lsst.ctrl.bps import BpsConfig
-from lsst.daf.butler.core.config import Config
+from lsst.daf.butler import Config
 
 TESTDIR = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
Config is lifted so no need to specify the path including core.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
