### PR TITLE
DM-42206: Remove --transfer-dimensions from final job.

### DIFF
--- a/doc/changes/DM-42206.bugfix.rst
+++ b/doc/changes/DM-42206.bugfix.rst
@@ -1,0 +1,1 @@
+Remove --transfer-dimensions from finaljob command.

--- a/doc/lsst.ctrl.bps/quickstart.rst
+++ b/doc/lsst.ctrl.bps/quickstart.rst
@@ -940,7 +940,6 @@ New YAML Section
        {butlerConfig}
        --register-dataset-types
        --update-output-chain
-       --transfer-dimensions
 
 **whenSetup**
     When during the submission process set up the final job.  Provided for

--- a/python/lsst/ctrl/bps/etc/bps_defaults.yaml
+++ b/python/lsst/ctrl/bps/etc/bps_defaults.yaml
@@ -122,4 +122,3 @@ finalJob:
     {butlerConfig}
     --register-dataset-types
     --update-output-chain
-    --transfer-dimensions


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
