### PR TITLE
DM-44156: Include memoryLimit in BPS defaults

### DIFF
--- a/doc/changes/DM-44156.misc.rst
+++ b/doc/changes/DM-44156.misc.rst
@@ -1,0 +1,1 @@
+Added a global default values for ``memoryLimit`` to let the users use the BPS automatic memory scaling mechanism.

--- a/python/lsst/ctrl/bps/etc/bps_defaults.yaml
+++ b/python/lsst/ctrl/bps/etc/bps_defaults.yaml
@@ -122,3 +122,14 @@ finalJob:
     {butlerConfig}
     --register-dataset-types
     --update-output-chain
+
+# Set a global default memory limit (in MiB) for the automatic memory scaling
+# mechanism. The value, 480 GiB, picked based on the cluster specifications
+# available at
+#
+#     https://s3df.slac.stanford.edu/public/doc/#/batch-compute
+#
+# When DM-44110 is completed, BPS plugins will be able to provide their
+# own defaults.  Currently, needs to be override in user's config
+# if a different limit needs to be used.
+memoryLimit: 491520


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
