### PR TITLE
DM-48768: Use Table.pformat() instead of the deprecated Table.pformat_all() in ctrl_bps

### DIFF
--- a/doc/changes/DM-48768.misc.rst
+++ b/doc/changes/DM-48768.misc.rst
@@ -1,0 +1,1 @@
+Replaced all calls to ``Table.pformat_all()`` in **ctrl_bps** with ``Table.pformat()`` as the former is being deprecated in **astropy** version 7.0.

--- a/python/lsst/ctrl/bps/bps_reports.py
+++ b/python/lsst/ctrl/bps/bps_reports.py
@@ -63,7 +63,7 @@ class BaseRunReport(abc.ABC):
         return len(self._table)
 
     def __str__(self):
-        lines = list(self._table.pformat_all())
+        lines = list(self._table.pformat())
         return "\n".join(lines)
 
     @property
@@ -221,7 +221,7 @@ class DetailedRunReport(BaseRunReport):
 
     def __str__(self):
         alignments = ["<"] + [">"] * (len(self._table.colnames) - 1)
-        lines = list(self._table.pformat_all(align=alignments))
+        lines = list(self._table.pformat(align=alignments))
         lines.insert(3, lines[1])
         return str("\n".join(lines))
 
@@ -272,7 +272,7 @@ class ExitCodesReport(BaseRunReport):
 
     def __str__(self):
         alignments = ["<"] + [">"] * (len(self._table.colnames) - 1)
-        lines = list(self._table.pformat_all(align=alignments))
+        lines = list(self._table.pformat(align=alignments))
         return str("\n".join(lines))
 
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -156,7 +156,7 @@ class SummaryRunReportTestCase(unittest.TestCase):
 
     def testAddWithNoFlag(self):
         """Test adding a report for a run with no issues."""
-        print("\n".join(self.expected.pformat_all()), file=self.expected_output)
+        print("\n".join(self.expected.pformat()), file=self.expected_output)
 
         self.report.add(self.run)
         print(self.report, file=self.actual_output)
@@ -166,7 +166,7 @@ class SummaryRunReportTestCase(unittest.TestCase):
     def testAddWithFailedFlag(self):
         """Test adding a run with a failed job."""
         self.expected["X"][0] = "F"
-        print("\n".join(self.expected.pformat_all()), file=self.expected_output)
+        print("\n".join(self.expected.pformat()), file=self.expected_output)
 
         # Alter the run report to include a failed job.
         self.run.job_state_counts = {
@@ -180,7 +180,7 @@ class SummaryRunReportTestCase(unittest.TestCase):
     def testAddWithHeldFlag(self):
         """Test adding a run with a held job."""
         self.expected["X"][0] = "H"
-        print("\n".join(self.expected.pformat_all()), file=self.expected_output)
+        print("\n".join(self.expected.pformat()), file=self.expected_output)
 
         # Alter the run report to include a held job.
         self.run.job_state_counts = {
@@ -194,7 +194,7 @@ class SummaryRunReportTestCase(unittest.TestCase):
     def testAddWithDeletedFlag(self):
         """Test adding a run with a deleted job."""
         self.expected["X"][0] = "D"
-        print("\n".join(self.expected.pformat_all()), file=self.expected_output)
+        print("\n".join(self.expected.pformat()), file=self.expected_output)
 
         # Alter the run report to include a deleted job.
         self.run.job_state_counts = {


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
