### PR TITLE
DM-48872: Restore the previous behavior of bps report in rubin-env-9

### DIFF
--- a/doc/changes/DM-48872.misc.rst
+++ b/doc/changes/DM-48872.misc.rst
@@ -1,0 +1,1 @@
+Adjusted options in BPS calls of ``Table.pformat()`` so the lines exceeding user's display size are wrapped instead of being truncated when using ``Astropy`` version 6.

--- a/python/lsst/ctrl/bps/bps_reports.py
+++ b/python/lsst/ctrl/bps/bps_reports.py
@@ -63,7 +63,7 @@ class BaseRunReport(abc.ABC):
         return len(self._table)
 
     def __str__(self):
-        lines = list(self._table.pformat())
+        lines = list(self._table.pformat(max_lines=-1, max_width=-1))
         return "\n".join(lines)
 
     @property
@@ -221,7 +221,7 @@ class DetailedRunReport(BaseRunReport):
 
     def __str__(self):
         alignments = ["<"] + [">"] * (len(self._table.colnames) - 1)
-        lines = list(self._table.pformat(align=alignments))
+        lines = list(self._table.pformat(max_lines=-1, max_width=-1, align=alignments))
         lines.insert(3, lines[1])
         return str("\n".join(lines))
 
@@ -272,7 +272,7 @@ class ExitCodesReport(BaseRunReport):
 
     def __str__(self):
         alignments = ["<"] + [">"] * (len(self._table.colnames) - 1)
-        lines = list(self._table.pformat(align=alignments))
+        lines = list(self._table.pformat(max_lines=-1, max_width=-1, align=alignments))
         return str("\n".join(lines))
 
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -157,7 +157,7 @@ class SummaryRunReportTestCase(unittest.TestCase):
 
     def testAddWithNoFlag(self):
         """Test adding a report for a run with no issues."""
-        print("\n".join(self.expected.pformat()), file=self.expected_output)
+        print("\n".join(self.expected.pformat(max_lines=-1, max_width=-1)), file=self.expected_output)
 
         self.report.add(self.run)
         print(self.report, file=self.actual_output)
@@ -167,7 +167,7 @@ class SummaryRunReportTestCase(unittest.TestCase):
     def testAddWithFailedFlag(self):
         """Test adding a run with a failed job."""
         self.expected["X"][0] = "F"
-        print("\n".join(self.expected.pformat()), file=self.expected_output)
+        print("\n".join(self.expected.pformat(max_lines=-1, max_width=-1)), file=self.expected_output)
 
         # Alter the run report to include a failed job.
         self.run.job_state_counts = {
@@ -181,7 +181,7 @@ class SummaryRunReportTestCase(unittest.TestCase):
     def testAddWithHeldFlag(self):
         """Test adding a run with a held job."""
         self.expected["X"][0] = "H"
-        print("\n".join(self.expected.pformat()), file=self.expected_output)
+        print("\n".join(self.expected.pformat(max_lines=-1, max_width=-1)), file=self.expected_output)
 
         # Alter the run report to include a held job.
         self.run.job_state_counts = {
@@ -195,7 +195,7 @@ class SummaryRunReportTestCase(unittest.TestCase):
     def testAddWithDeletedFlag(self):
         """Test adding a run with a deleted job."""
         self.expected["X"][0] = "D"
-        print("\n".join(self.expected.pformat()), file=self.expected_output)
+        print("\n".join(self.expected.pformat(max_lines=-1, max_width=-1)), file=self.expected_output)
 
         # Alter the run report to include a deleted job.
         self.run.job_state_counts = {


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
