### PR TITLE
DM-48948: Print PipelineTask cycle if found when clustering.

### DIFF
--- a/doc/changes/DM-48948.misc.rst
+++ b/doc/changes/DM-48948.misc.rst
@@ -1,0 +1,1 @@
+Modified code to print PipelineTask cycle if one is found when clustering.


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
