### PR TITLE
DM-50498: Ensure all job environment values are strings.

### DIFF
--- a/doc/changes/DM-50498.misc.rst
+++ b/doc/changes/DM-50498.misc.rst
@@ -1,0 +1,1 @@
+Ensured all job environment values are strings in the GenericWorkflow.

--- a/python/lsst/ctrl/bps/transform.py
+++ b/python/lsst/ctrl/bps/transform.py
@@ -416,7 +416,7 @@ def _get_job_values(config, search_opt, cmd_line_key):
         search_opt["replaceVars"] = True
         job_values["environment"] = {}
         for name in job_env:
-            job_values["environment"][name] = config.search(name, search_opt)[1]
+            job_values["environment"][name] = str(config.search(name, search_opt)[1])
         if old_searchobj is None:
             del search_opt["searchobj"]
         else:

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -189,25 +189,25 @@ class TestGetJobValues(unittest.TestCase):
         config = BpsConfig(
             {
                 "var1": "two",
-                "environment": {"TEST_INT": 1, "TEST_SPACES": "one {var1} three"},
+                "environment": {"TEST_INT": 1, "TEST_BOOL": False, "TEST_SPACES": "one {var1} three"},
             }
         )
         job_values = _get_job_values(config, {}, None)
-        truth = BpsConfig({"TEST_INT": 1, "TEST_SPACES": "one two three"}, {}, None)
+        truth = BpsConfig({"TEST_INT": "1", "TEST_BOOL": "False", "TEST_SPACES": "one two three"}, {}, None)
         self.assertEqual(truth, job_values["environment"])
 
     def testEnvironmentOptions(self):
         config = BpsConfig(
             {
                 "var1": "two",
-                "environment": {"TEST_INT": 1, "TEST_SPACES": "one {var1} three"},
+                "environment": {"TEST_INT": 1, "TEST_BOOL": False, "TEST_SPACES": "one {var1} three"},
                 "finalJob": {"requestMemory": 8096, "command1": "/usr/bin/env"},
             }
         )
         search_obj = config["finalJob"]
         search_opts = {"replaceVars": False, "searchobj": search_obj}
         job_values = _get_job_values(config, search_opts, None)
-        truth = {"TEST_INT": 1, "TEST_SPACES": "one two three"}
+        truth = {"TEST_INT": "1", "TEST_BOOL": "False", "TEST_SPACES": "one two three"}
         self.assertEqual(truth, job_values["environment"])
         self.assertEqual(search_opts["replaceVars"], False)
         self.assertEqual(search_opts["searchobj"]["requestMemory"], 8096)


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
