### PR TITLE
DM-54588: Release notes for v30.0.6

### DIFF
--- a/doc/changes/DM-53292.feature.rst
+++ b/doc/changes/DM-53292.feature.rst
@@ -1,1 +1,0 @@
-Implemented `wmsAttemptNum` with generic wms variable placeholders.

--- a/doc/changes/DM-54466.bugfix.rst
+++ b/doc/changes/DM-54466.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed bug that converts s3:// to s3:/.  Changed code to only remove double slashes with subDirTemplate since we are guaranteed it is used as part of a path and doesn't include a scheme.

--- a/doc/lsst.ctrl.bps/CHANGES.rst
+++ b/doc/lsst.ctrl.bps/CHANGES.rst
@@ -1,3 +1,12 @@
+lsst-ctrl-bps v30.0.6 (2026-04-06)
+==================================
+
+New Features
+------------
+
+- Implemented ``wmsAttemptNum`` with generic WMS variable placeholders. (`DM-53292 <https://rubinobs.atlassian.net/browse/DM-53292>`_)
+
+
 lsst-ctrl-bps v30.0.1 (2026-02-03)
 ==================================
 


### PR DESCRIPTION
Do not include the news fragment from DM-54466 since that was describing a bug fix introduced in by the other ticket described in the release notes and so was never part of a public release.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
